### PR TITLE
Remove redundant close parentheses in stats.cpumhz

### DIFF
--- a/release/src/router/www/js/status-data.jsx
+++ b/release/src/router/www/js/status-data.jsx
@@ -36,7 +36,7 @@ do {
 		reloadPage();
 	}
 	stats.flashsize = sysinfo.flashsize+'MB';
-	stats.cpumhz = sysinfo.cpuclk+'MHz)';
+	stats.cpumhz = sysinfo.cpuclk+'MHz';
 	stats.cputemp = sysinfo.cputemp+'°';
 	stats.systemtype = sysinfo.systemtype;
 	stats.cpuload = ((sysinfo.loads[0] / 65536.0).toFixed(2) + '<small> / </small> ' +


### PR DESCRIPTION
stats.cpumhz contains an unnecessary close parentheses, so instead of "xxxMHz" it would be "xxxMHz)"
![image](https://cloud.githubusercontent.com/assets/1905496/13903800/f63d1110-eebb-11e5-8563-7e5c7ebb487e.png)
