### PR TITLE
ui: keep utilization tabs on screen

### DIFF
--- a/release/src/router/www/css/interface.css
+++ b/release/src/router/www/css/interface.css
@@ -1417,6 +1417,7 @@ a.close:hover {
   line-height: 1.2;
   border: solid #f0f0f0;
   border-width: 1px 0 0 1px;
+  float: left;
 }
 
 .btn.btn-tab:hover,


### PR DESCRIPTION
The Bandwidth and IP Traffic pages use tabs to list their interfaces and
hostnames respectively. They tabs will run off the right edge of the
window if the window is too narrow to display them all.

By floating .tab-nav, we can have it overflow and run down the page
rather than off of it.

https://www.evernote.com/l/ABH15cYviVlApbF2mlTtIUQfGPcnKnDUtI4 shows the second row of tabs; now on-screen and visible.